### PR TITLE
fix(deps): pin Microsoft.OpenApi 2.9.0 explicitly

### DIFF
--- a/Digital.Net.Core.Http/Digital.Net.Core.Http.csproj
+++ b/Digital.Net.Core.Http/Digital.Net.Core.Http.csproj
@@ -15,6 +15,7 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.9"/>
+        <PackageReference Include="Microsoft.OpenApi" Version="2.9.0"/>
         <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.9"/>
         <PackageReference Include="Scalar.AspNetCore" Version="2.16.3"/>
         <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.9"/>


### PR DESCRIPTION
Ajoute une référence explicite à **`Microsoft.OpenApi 2.9.0`** dans `Digital.Net.Core.Http`.

Corrige **GHSA-v5pm-xwqc-g5wc** (HIGH) — *circular schema references may terminate OpenAPI parsing* — remonté par l'audit sécurité du 2026-08-09 de `safaridigital.fr-digital.net`, où la version résolue était `2.0.0`.

## Pourquoi une référence explicite plutôt qu'une montée

Le rapport d'audit indiquait « correctif à vérifier (non indiqué par la source) ». L'avis en a bien un :

```
affected     : >= 2.0.0-preview.11, <= 2.7.4
first patched: 2.7.5
```

Le paquet arrive **transitivement** via `Microsoft.AspNetCore.OpenApi`, qui épingle exactement `2.0.0` — et le fait **toujours en 10.0.10**. Les deux nuspecs sont identiques sur ce point :

```
Microsoft.AspNetCore.OpenApi 10.0.9  -> Microsoft.OpenApi 2.0.0
Microsoft.AspNetCore.OpenApi 10.0.10 -> Microsoft.OpenApi 2.0.0
```

Aucune montée du parent n'atteint donc le correctif. La règle « référence directe l'emporte sur le plancher transitif » de NuGet est le seul levier.

Version retenue : **2.9.0**, la dernière de la ligne 2.x. La `latest` est 3.9.0 — une majeure que l'intégration ASP.NET Core ne cible pas.

## Vérifications

- `dotnet build SafariDigital.slnx` → **Build succeeded**
- `project.assets.json` résout bien `Microsoft.OpenApi/2.9.0` (au lieu de `2.0.0`), pour `Digital.Net.Core.Http` comme pour `SafariDigital.Api`

`Scalar.AspNetCore 2.16.3` consomme aussi `Microsoft.OpenApi` : la compilation passe, mais **le rendu du document OpenAPI et l'UI Scalar méritent un coup d'œil en recette**, le saut 2.0.0 → 2.9.0 n'étant pas anodin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
